### PR TITLE
Removed one .root file that caused crashes

### DIFF
--- a/RunII_102X_v1/2017/DATA_SingleElectron_Run2017F.xml
+++ b/RunII_102X_v1/2017/DATA_SingleElectron_Run2017F.xml
@@ -243,7 +243,7 @@
 <In FileName="/pnfs/desy.de/cms/tier2/store/user/xuchen/RunII_102X_v1/2017v2/SingleElectron/crab_SingleElectron_Run2017F/190819_213830/0000/Ntuple_317.root" Lumi="0.0"/>
 <In FileName="/pnfs/desy.de/cms/tier2/store/user/xuchen/RunII_102X_v1/2017v2/SingleElectron/crab_SingleElectron_Run2017F/190819_213830/0000/Ntuple_318.root" Lumi="0.0"/>
 <In FileName="/pnfs/desy.de/cms/tier2/store/user/xuchen/RunII_102X_v1/2017v2/SingleElectron/crab_SingleElectron_Run2017F/190819_213830/0000/Ntuple_319.root" Lumi="0.0"/>
-<In FileName="/pnfs/desy.de/cms/tier2/store/user/xuchen/RunII_102X_v1/2017v2/SingleElectron/crab_SingleElectron_Run2017F/190819_213830/0000/Ntuple_32.root" Lumi="0.0"/>
+<!--<In FileName="/pnfs/desy.de/cms/tier2/store/user/xuchen/RunII_102X_v1/2017v2/SingleElectron/crab_SingleElectron_Run2017F/190819_213830/0000/Ntuple_32.root" Lumi="0.0"/>-->
 <In FileName="/pnfs/desy.de/cms/tier2/store/user/xuchen/RunII_102X_v1/2017v2/SingleElectron/crab_SingleElectron_Run2017F/190819_213830/0000/Ntuple_320.root" Lumi="0.0"/>
 <In FileName="/pnfs/desy.de/cms/tier2/store/user/xuchen/RunII_102X_v1/2017v2/SingleElectron/crab_SingleElectron_Run2017F/190819_213830/0000/Ntuple_321.root" Lumi="0.0"/>
 <In FileName="/pnfs/desy.de/cms/tier2/store/user/xuchen/RunII_102X_v1/2017v2/SingleElectron/crab_SingleElectron_Run2017F/190819_213830/0000/Ntuple_322.root" Lumi="0.0"/>


### PR DESCRIPTION
Event number 11778 in this file would cause the following error:

` ( FATAL )  sframe_main        : app/sframe_main.cxx:70 (int main(int, char**)): STD exception caught
 ( FATAL )  sframe_main        : app/sframe_main.cxx:71 (int main(int, char**)): Message: vector::_M_default_append
 ( FATAL )  sframe_main        : app/sframe_main.cxx:72 (int main(int, char**)): --> Stopping execution
`

One branch in the AnalysisTree is faulty.

The effect on the integrated lumi is negligible as we have >>1000 files in this dataset.