### PR TITLE
remove deprecated verbose parameter from namedtple

### DIFF
--- a/CrossSectionHelper.py
+++ b/CrossSectionHelper.py
@@ -1,7 +1,7 @@
 from collections import namedtuple,Mapping
 
 def namedtuple_with_defaults(typename, field_names, default_values=()):
-    T = namedtuple(typename, field_names, verbose=False)
+    T = namedtuple(typename, field_names)
     T.__new__.__defaults__ = (None,) * len(T._fields)
     if isinstance(default_values, Mapping):
         prototype = T(**default_values)


### PR DESCRIPTION
verbose is no longer a kwarg since Python 3.7