### PR TITLE
[102X_v2] delete empty xml duplicates

### DIFF
--- a/RunII_102X_v2/2018/VBF_BulkGravToWW/VBF_BulkGravToWW_narrow_M-600_TuneCP5_PSWeights.xml
+++ b/RunII_102X_v2/2018/VBF_BulkGravToWW/VBF_BulkGravToWW_narrow_M-600_TuneCP5_PSWeights.xml
@@ -1,1 +1,0 @@
-<!-- < NumberEntries="0" Method=fast /> -->


### PR DESCRIPTION
This PR removes the following two empty xml files, since these files were probably added mistakenly:
```RunII_102X_v2/2018/VBF_BulkGravToWW/VBF_BulkGravToWW_narrow_M-600_TuneCP5_PSWeights.xml```
```RunII_102X_v2/2018/VBF_BulkGravToWW/VBF_BulkGravToWW_narrow_M-800_TuneCP5_PSWeights.xml```

The correct files to use are (note the small ```w``` in ```PSweights```):
```RunII_102X_v2/2018/VBF_BulkGravToWW/VBF_BulkGravToWW_narrow_M-600_TuneCP5_PSweights.xml```
```RunII_102X_v2/2018/VBF_BulkGravToWW/VBF_BulkGravToWW_narrow_M-800_TuneCP5_PSweights.xml```

This should prevent the "colliding paths error" on case-insensitive file systems like MacOS.