### PR TITLE
[106X] remove not needed comment

### DIFF
--- a/RunII_106X_v2/data/UL16preVFP/SingleElectron_Run2016B_HIPM_UL2016_MiniAODv2-v2.xml
+++ b/RunII_106X_v2/data/UL16preVFP/SingleElectron_Run2016B_HIPM_UL2016_MiniAODv2-v2.xml
@@ -27,7 +27,7 @@
 <In FileName="/pnfs/desy.de/cms/tier2//store/group/uhh/uhh2ntuples/RunII_106X_v2/UL16preVFP/SingleElectron/crab_SingleElectron_Run2016B-ver1_HIPM_UL2016_MiniAODv2-v2/211123_170723/0000/Ntuple_7.root" Lumi="0.0"/>
 <In FileName="/pnfs/desy.de/cms/tier2//store/group/uhh/uhh2ntuples/RunII_106X_v2/UL16preVFP/SingleElectron/crab_SingleElectron_Run2016B-ver1_HIPM_UL2016_MiniAODv2-v2/211123_170723/0000/Ntuple_8.root" Lumi="0.0"/>
 <In FileName="/pnfs/desy.de/cms/tier2//store/group/uhh/uhh2ntuples/RunII_106X_v2/UL16preVFP/SingleElectron/crab_SingleElectron_Run2016B-ver1_HIPM_UL2016_MiniAODv2-v2/211123_170723/0000/Ntuple_9.root" Lumi="0.0"/>
-<!-- < NumberEntries="1422819" Method=fast /> --><In FileName="/pnfs/desy.de/cms/tier2//store/group/uhh/uhh2ntuples/RunII_106X_v2/UL16preVFP/SingleElectron/crab_SingleElectron_Run2016B-ver2_HIPM_UL2016_MiniAODv2-v2/211124_151730/0000/Ntuple_1.root" Lumi="0.0"/>
+<In FileName="/pnfs/desy.de/cms/tier2//store/group/uhh/uhh2ntuples/RunII_106X_v2/UL16preVFP/SingleElectron/crab_SingleElectron_Run2016B-ver2_HIPM_UL2016_MiniAODv2-v2/211124_151730/0000/Ntuple_1.root" Lumi="0.0"/>
 <In FileName="/pnfs/desy.de/cms/tier2//store/group/uhh/uhh2ntuples/RunII_106X_v2/UL16preVFP/SingleElectron/crab_SingleElectron_Run2016B-ver2_HIPM_UL2016_MiniAODv2-v2/211124_151730/0000/Ntuple_10.root" Lumi="0.0"/>
 <In FileName="/pnfs/desy.de/cms/tier2//store/group/uhh/uhh2ntuples/RunII_106X_v2/UL16preVFP/SingleElectron/crab_SingleElectron_Run2016B-ver2_HIPM_UL2016_MiniAODv2-v2/211124_151730/0000/Ntuple_100.root" Lumi="0.0"/>
 <In FileName="/pnfs/desy.de/cms/tier2//store/group/uhh/uhh2ntuples/RunII_106X_v2/UL16preVFP/SingleElectron/crab_SingleElectron_Run2016B-ver2_HIPM_UL2016_MiniAODv2-v2/211124_151730/0000/Ntuple_101.root" Lumi="0.0"/>


### PR DESCRIPTION
In one xml file I spotted a comment from the event counting which was probably added by mistake, therefore I removed it.
The total number of events is already given in the last line.