### PR TITLE
Updating python tests action

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - name: Set up Python 3.6
-        uses: actions/setup-python@v1
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v3
         with:
-          python-version: 3.6
+          python-version: 3.9
 
       - name: basic python testing
         run: |


### PR DESCRIPTION
This updates both the actions and the python version used in the workflow.
This is needed in order to stay compatible with `ubuntu-latest`, as @danielhundhausen pointed out in #207.
The move to python 3.9 is needed, since python 3.6 is not available in ubuntu22.