### PR TITLE
updated ttbar cross section value @13TeV

### DIFF
--- a/CrossSectionHelper.py
+++ b/CrossSectionHelper.py
@@ -787,7 +787,7 @@ class MCSampleValuesHelper(MCSampleValuesHelperPrototype):
         },
 
         "TTTo2L2Nu" : {
-            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=831.76, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
+            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=833.9, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
             "BranchingRatio" : MCSampleValuesHelperPrototype.BRValues(BRat_13TeV=0.105, BRatSource_13TeV="https://pdg.lbl.gov/2020/reviews/rpp2020-rev-top-quark.pdf (page 2)"),
             "NEvents" : MCSampleValuesHelperPrototype.NEventsValues(
                 NEVT_UL16preVFP=2680294258.52,
@@ -804,7 +804,7 @@ class MCSampleValuesHelper(MCSampleValuesHelperPrototype):
         },
 
         "TTToSemiLeptonic" : {
-            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=831.76, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
+            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=833.9, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
             "BranchingRatio" : MCSampleValuesHelperPrototype.BRValues(BRat_13TeV=0.438, BRatSource_13TeV="https://pdg.lbl.gov/2020/reviews/rpp2020-rev-top-quark.pdf (page 2)"),
             "NEvents" : MCSampleValuesHelperPrototype.NEventsValues(
                 NEVT_UL16preVFP=39046225860.2,
@@ -821,7 +821,7 @@ class MCSampleValuesHelper(MCSampleValuesHelperPrototype):
         },
 
         "TTToHadronic" : {
-            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=831.76, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
+            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=833.9, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
             "BranchingRatio" : MCSampleValuesHelperPrototype.BRValues(BRat_13TeV=0.457, BRatSource_13TeV="https://pdg.lbl.gov/2020/reviews/rpp2020-rev-top-quark.pdf (page 2)"),
             "NEvents" : MCSampleValuesHelperPrototype.NEventsValues(
                 NEVT_UL16preVFP=30289246641.2,
@@ -838,7 +838,7 @@ class MCSampleValuesHelper(MCSampleValuesHelperPrototype):
         },
 
         "TTTo2L2Nu_hdampDOWN" : {
-            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=831.76, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
+            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=833.9, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
             "BranchingRatio" : MCSampleValuesHelperPrototype.BRValues(BRat_13TeV=0.105, BRatSource_13TeV="https://pdg.lbl.gov/2020/reviews/rpp2020-rev-top-quark.pdf (page 2)"),
             "NEvents" : MCSampleValuesHelperPrototype.NEventsValues(
                 NEVT_UL16preVFP=1197862430.31,
@@ -855,7 +855,7 @@ class MCSampleValuesHelper(MCSampleValuesHelperPrototype):
         },
 
         "TTToSemiLeptonic_hdampDOWN" : {
-            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=831.76, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
+            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=833.9, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
             "BranchingRatio" : MCSampleValuesHelperPrototype.BRValues(BRat_13TeV=0.438, BRatSource_13TeV="https://pdg.lbl.gov/2020/reviews/rpp2020-rev-top-quark.pdf (page 2)"),
             "NEvents" : MCSampleValuesHelperPrototype.NEventsValues(
                 NEVT_UL16preVFP=13961893555.7,
@@ -872,7 +872,7 @@ class MCSampleValuesHelper(MCSampleValuesHelperPrototype):
         },
 
         "TTToHadronic_hdampDOWN" : {
-            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=831.76, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
+            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=833.9, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
             "BranchingRatio" : MCSampleValuesHelperPrototype.BRValues(BRat_13TeV=0.457, BRatSource_13TeV="https://pdg.lbl.gov/2020/reviews/rpp2020-rev-top-quark.pdf (page 2)"),
             "NEvents" : MCSampleValuesHelperPrototype.NEventsValues(
                 NEVT_UL16preVFP=11446167870.6,
@@ -889,7 +889,7 @@ class MCSampleValuesHelper(MCSampleValuesHelperPrototype):
         },
 
         "TTTo2L2Nu_hdampUP" : {
-            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=831.76, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
+            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=833.9, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
             "BranchingRatio" : MCSampleValuesHelperPrototype.BRValues(BRat_13TeV=0.105, BRatSource_13TeV="https://pdg.lbl.gov/2020/reviews/rpp2020-rev-top-quark.pdf (page 2)"),
             "NEvents" : MCSampleValuesHelperPrototype.NEventsValues(
                 NEVT_UL16preVFP=1061555213.51,
@@ -906,7 +906,7 @@ class MCSampleValuesHelper(MCSampleValuesHelperPrototype):
         },
 
         "TTToSemiLeptonic_hdampUP" : {
-            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=831.76, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
+            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=833.9, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
             "BranchingRatio" : MCSampleValuesHelperPrototype.BRValues(BRat_13TeV=0.438, BRatSource_13TeV="https://pdg.lbl.gov/2020/reviews/rpp2020-rev-top-quark.pdf (page 2)"),
             "NEvents" : MCSampleValuesHelperPrototype.NEventsValues(
                 NEVT_UL16preVFP=16817574381.2,
@@ -923,7 +923,7 @@ class MCSampleValuesHelper(MCSampleValuesHelperPrototype):
         },
 
         "TTToHadronic_hdampUP" : {
-            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=831.76, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
+            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=833.9, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
             "BranchingRatio" : MCSampleValuesHelperPrototype.BRValues(BRat_13TeV=0.457, BRatSource_13TeV="https://pdg.lbl.gov/2020/reviews/rpp2020-rev-top-quark.pdf (page 2)"),
             "NEvents" : MCSampleValuesHelperPrototype.NEventsValues(
                 NEVT_UL16preVFP=9358050857.84,
@@ -940,7 +940,7 @@ class MCSampleValuesHelper(MCSampleValuesHelperPrototype):
         },
 
         "TTTo2L2Nu_CR1" : {
-            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=831.76, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
+            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=833.9, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
             "BranchingRatio" : MCSampleValuesHelperPrototype.BRValues(BRat_13TeV=0.105, BRatSource_13TeV="https://pdg.lbl.gov/2020/reviews/rpp2020-rev-top-quark.pdf (page 2)"),
             "NEvents" : MCSampleValuesHelperPrototype.NEventsValues(
                 NEVT_UL16preVFP=1023859348.4,
@@ -957,7 +957,7 @@ class MCSampleValuesHelper(MCSampleValuesHelperPrototype):
         },
 
         "TTToSemiLeptonic_CR1" : {
-            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=831.76, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
+            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=833.9, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
             "BranchingRatio" : MCSampleValuesHelperPrototype.BRValues(BRat_13TeV=0.438, BRatSource_13TeV="https://pdg.lbl.gov/2020/reviews/rpp2020-rev-top-quark.pdf (page 2)"),
             "NEvents" : MCSampleValuesHelperPrototype.NEventsValues(
                 NEVT_UL16preVFP=15563564465.2,
@@ -974,7 +974,7 @@ class MCSampleValuesHelper(MCSampleValuesHelperPrototype):
         },
 
         "TTToHadronic_CR1" : {
-            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=831.76, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
+            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=833.9, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
             "BranchingRatio" : MCSampleValuesHelperPrototype.BRValues(BRat_13TeV=0.457, BRatSource_13TeV="https://pdg.lbl.gov/2020/reviews/rpp2020-rev-top-quark.pdf (page 2)"),
             "NEvents" : MCSampleValuesHelperPrototype.NEventsValues(
                 NEVT_UL16preVFP=11268884747.0,
@@ -991,7 +991,7 @@ class MCSampleValuesHelper(MCSampleValuesHelperPrototype):
         },
 
         "TTTo2L2Nu_CR2" : {
-            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=831.76, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
+            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=833.9, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
             "BranchingRatio" : MCSampleValuesHelperPrototype.BRValues(BRat_13TeV=0.105, BRatSource_13TeV="https://pdg.lbl.gov/2020/reviews/rpp2020-rev-top-quark.pdf (page 2)"),
             "NEvents" : MCSampleValuesHelperPrototype.NEventsValues(
                 NEVT_UL16preVFP=1209778279.97,
@@ -1008,7 +1008,7 @@ class MCSampleValuesHelper(MCSampleValuesHelperPrototype):
         },
 
         "TTToSemiLeptonic_CR2" : {
-            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=831.76, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
+            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=833.9, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
             "BranchingRatio" : MCSampleValuesHelperPrototype.BRValues(BRat_13TeV=0.438, BRatSource_13TeV="https://pdg.lbl.gov/2020/reviews/rpp2020-rev-top-quark.pdf (page 2)"),
             "NEvents" : MCSampleValuesHelperPrototype.NEventsValues(
                 NEVT_UL16preVFP=16948358553.1,
@@ -1025,7 +1025,7 @@ class MCSampleValuesHelper(MCSampleValuesHelperPrototype):
         },
 
         "TTToHadronic_CR2" : {
-            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=831.76, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
+            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=833.9, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
             "BranchingRatio" : MCSampleValuesHelperPrototype.BRValues(BRat_13TeV=0.457, BRatSource_13TeV="https://pdg.lbl.gov/2020/reviews/rpp2020-rev-top-quark.pdf (page 2)"),
             "NEvents" : MCSampleValuesHelperPrototype.NEventsValues(
                 NEVT_UL16preVFP=12523219904.4,
@@ -1042,7 +1042,7 @@ class MCSampleValuesHelper(MCSampleValuesHelperPrototype):
         },
 
         "TTTo2L2Nu_erdON" : {
-            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=831.76, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
+            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=833.9, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
             "BranchingRatio" : MCSampleValuesHelperPrototype.BRValues(BRat_13TeV=0.105, BRatSource_13TeV="https://pdg.lbl.gov/2020/reviews/rpp2020-rev-top-quark.pdf (page 2)"),
             "NEvents" : MCSampleValuesHelperPrototype.NEventsValues(
                 NEVT_UL16preVFP=1166883518.38,
@@ -1059,7 +1059,7 @@ class MCSampleValuesHelper(MCSampleValuesHelperPrototype):
         },
 
         "TTToSemiLeptonic_erdON" : {
-            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=831.76, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
+            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=833.9, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
             "BranchingRatio" : MCSampleValuesHelperPrototype.BRValues(BRat_13TeV=0.438, BRatSource_13TeV="https://pdg.lbl.gov/2020/reviews/rpp2020-rev-top-quark.pdf (page 2)"),
             "NEvents" : MCSampleValuesHelperPrototype.NEventsValues(
                 NEVT_UL16preVFP=16726593539.7,
@@ -1076,7 +1076,7 @@ class MCSampleValuesHelper(MCSampleValuesHelperPrototype):
         },
 
         "TTToHadronic_erdON" : {
-            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=831.76, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
+            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=833.9, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
             "BranchingRatio" : MCSampleValuesHelperPrototype.BRValues(BRat_13TeV=0.457, BRatSource_13TeV="https://pdg.lbl.gov/2020/reviews/rpp2020-rev-top-quark.pdf (page 2)"),
             "NEvents" : MCSampleValuesHelperPrototype.NEventsValues(
                 NEVT_UL16preVFP=11871224618.2,
@@ -1093,7 +1093,7 @@ class MCSampleValuesHelper(MCSampleValuesHelperPrototype):
         },
 
         "TTTo2L2Nu_TuneCP5down" : {
-            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=831.76, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
+            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=833.9, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
             "BranchingRatio" : MCSampleValuesHelperPrototype.BRValues(BRat_13TeV=0.105, BRatSource_13TeV="https://pdg.lbl.gov/2020/reviews/rpp2020-rev-top-quark.pdf (page 2)"),
             "NEvents" : MCSampleValuesHelperPrototype.NEventsValues(
                 NEVT_UL16preVFP=1200799748.55,
@@ -1110,7 +1110,7 @@ class MCSampleValuesHelper(MCSampleValuesHelperPrototype):
         },
 
         "TTToSemiLeptonic_TuneCP5down" : {
-            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=831.76, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
+            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=833.9, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
             "BranchingRatio" : MCSampleValuesHelperPrototype.BRValues(BRat_13TeV=0.438, BRatSource_13TeV="https://pdg.lbl.gov/2020/reviews/rpp2020-rev-top-quark.pdf (page 2)"),
             "NEvents" : MCSampleValuesHelperPrototype.NEventsValues(
                 NEVT_UL16preVFP=16533387862.2,
@@ -1127,7 +1127,7 @@ class MCSampleValuesHelper(MCSampleValuesHelperPrototype):
         },
 
         "TTToHadronic_TuneCP5down" : {
-            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=831.76, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
+            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=833.9, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
             "BranchingRatio" : MCSampleValuesHelperPrototype.BRValues(BRat_13TeV=0.457, BRatSource_13TeV="https://pdg.lbl.gov/2020/reviews/rpp2020-rev-top-quark.pdf (page 2)"),
             "NEvents" : MCSampleValuesHelperPrototype.NEventsValues(
                 NEVT_UL16preVFP=11678002502.4,
@@ -1144,7 +1144,7 @@ class MCSampleValuesHelper(MCSampleValuesHelperPrototype):
         },
 
         "TTTo2L2Nu_TuneCP5up" : {
-            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=831.76, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
+            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=833.9, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
             "BranchingRatio" : MCSampleValuesHelperPrototype.BRValues(BRat_13TeV=0.105, BRatSource_13TeV="https://pdg.lbl.gov/2020/reviews/rpp2020-rev-top-quark.pdf (page 2)"),
             "NEvents" : MCSampleValuesHelperPrototype.NEventsValues(
                 NEVT_UL16preVFP=734714642.148,
@@ -1161,7 +1161,7 @@ class MCSampleValuesHelper(MCSampleValuesHelperPrototype):
         },
 
         "TTToSemiLeptonic_TuneCP5up" : {
-            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=831.76, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
+            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=833.9, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
             "BranchingRatio" : MCSampleValuesHelperPrototype.BRValues(BRat_13TeV=0.438, BRatSource_13TeV="https://pdg.lbl.gov/2020/reviews/rpp2020-rev-top-quark.pdf (page 2)"),
             "NEvents" : MCSampleValuesHelperPrototype.NEventsValues(
                 NEVT_UL16preVFP=13853464424.1,
@@ -1178,7 +1178,7 @@ class MCSampleValuesHelper(MCSampleValuesHelperPrototype):
         },
 
         "TTToHadronic_TuneCP5up" : {
-            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=831.76, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
+            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=833.9, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
             "BranchingRatio" : MCSampleValuesHelperPrototype.BRValues(BRat_13TeV=0.457, BRatSource_13TeV="https://pdg.lbl.gov/2020/reviews/rpp2020-rev-top-quark.pdf (page 2)"),
             "NEvents" : MCSampleValuesHelperPrototype.NEventsValues(
                 NEVT_UL16preVFP=8903470364.36,
@@ -1195,7 +1195,7 @@ class MCSampleValuesHelper(MCSampleValuesHelperPrototype):
         },
 
         "TTTo2L2Nu_mtop171p5" : {
-            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=831.76, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
+            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=833.9, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
             "BranchingRatio" : MCSampleValuesHelperPrototype.BRValues(BRat_13TeV=0.105, BRatSource_13TeV="https://pdg.lbl.gov/2020/reviews/rpp2020-rev-top-quark.pdf (page 2)"),
             "NEvents" : MCSampleValuesHelperPrototype.NEventsValues(
                 NEVT_UL16preVFP=1225860665.17,
@@ -1212,7 +1212,7 @@ class MCSampleValuesHelper(MCSampleValuesHelperPrototype):
         },
 
         "TTToSemiLeptonic_mtop171p5" : {
-            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=831.76, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
+            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=833.9, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
             "BranchingRatio" : MCSampleValuesHelperPrototype.BRValues(BRat_13TeV=0.438, BRatSource_13TeV="https://pdg.lbl.gov/2020/reviews/rpp2020-rev-top-quark.pdf (page 2)"),
             "NEvents" : MCSampleValuesHelperPrototype.NEventsValues(
                 NEVT_UL16preVFP=16178279103.6,
@@ -1229,7 +1229,7 @@ class MCSampleValuesHelper(MCSampleValuesHelperPrototype):
         },
 
         "TTToHadronic_mtop171p5" : {
-            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=831.76, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
+            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=833.9, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
             "BranchingRatio" : MCSampleValuesHelperPrototype.BRValues(BRat_13TeV=0.457, BRatSource_13TeV="https://pdg.lbl.gov/2020/reviews/rpp2020-rev-top-quark.pdf (page 2)"),
             "NEvents" : MCSampleValuesHelperPrototype.NEventsValues(
                 NEVT_UL16preVFP=10181482920.6,
@@ -1246,7 +1246,7 @@ class MCSampleValuesHelper(MCSampleValuesHelperPrototype):
         },
 
         "TTTo2L2Nu_mtop173p5" : {
-            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=831.76, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
+            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=833.9, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
             "BranchingRatio" : MCSampleValuesHelperPrototype.BRValues(BRat_13TeV=0.105, BRatSource_13TeV="https://pdg.lbl.gov/2020/reviews/rpp2020-rev-top-quark.pdf (page 2)"),
             "NEvents" : MCSampleValuesHelperPrototype.NEventsValues(
                 NEVT_UL16preVFP=1159308909.57,
@@ -1263,7 +1263,7 @@ class MCSampleValuesHelper(MCSampleValuesHelperPrototype):
         },
 
         "TTToSemiLeptonic_mtop173p5" : {
-            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=831.76, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
+            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=833.9, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
             "BranchingRatio" : MCSampleValuesHelperPrototype.BRValues(BRat_13TeV=0.438, BRatSource_13TeV="https://pdg.lbl.gov/2020/reviews/rpp2020-rev-top-quark.pdf (page 2)"),
             "NEvents" : MCSampleValuesHelperPrototype.NEventsValues(
                 NEVT_UL16preVFP=15587693502.1,
@@ -1280,7 +1280,7 @@ class MCSampleValuesHelper(MCSampleValuesHelperPrototype):
         },
 
         "TTToHadronic_mtop173p5" : {
-            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=831.76, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
+            "CrossSection" : MCSampleValuesHelperPrototype.XSValues(XSec_13TeV=833.9, XSecSource_13TeV="https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO"),
             "BranchingRatio" : MCSampleValuesHelperPrototype.BRValues(BRat_13TeV=0.457, BRatSource_13TeV="https://pdg.lbl.gov/2020/reviews/rpp2020-rev-top-quark.pdf (page 2)"),
             "NEvents" : MCSampleValuesHelperPrototype.NEventsValues(
                 NEVT_UL16preVFP=11586470023.2,


### PR DESCRIPTION
I happened to noticed that the nominal cross section of ttbar @13TeV was updated in the corresponding [twiki](https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO#Updated_reference_cross_sections).

I was wondering how we make sure that we use the latest recommendations for cross section, branching fraction, etc. in general.
Maybe we can think of some kind of procedure to check regularly?
Although it seems to me that there's no way to avoid checking all the sources individually, which is quite tedious.
Perhaps it could help to add a date from the latest check as a first step? Just thinking out loud here...

What do people think on this?
(probably we should create a separate issue for this)